### PR TITLE
Handle stream cleanup without needing additional messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ name = "seabird-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "dotenv",
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 dotenv = "0.15"
 futures = "0.3"
 hyper = "0.13"

--- a/src/server.rs
+++ b/src/server.rs
@@ -656,13 +656,17 @@ impl Seabird for Arc<Server> {
                         })
                     }
                     Either::Left((Some(Err(err)), _)) => {
-                        Err(Status::internal(format!("failed to read internal event: {:?}", err)))
+                        Err(Status::internal(format!("failed to read internal event: {}", err)))
                     }
                     Either::Left((None, _)) => {
-                        Err(Status::internal(format!("this means something")))
+                        // Stream was closed by the server. In the future, maybe
+                        // this could be used to notify client streams that
+                        // seabird-core is restarting.
+                        Err(Status::internal("input stream ended unexpectedly".to_string()))
                     }
-                    Either::Right((_, _evt)) => {
-                        Err(Status::internal(format!("stream closed")))
+                    Either::Right((_, _)) => {
+                        // Stream was closed by the client - this is not actually an error.
+                        Ok(())
                     }
                 }?;
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -191,10 +191,14 @@ struct CommandsHandle {
 impl Drop for CommandsHandle {
     fn drop(&mut self) {
         debug!("dropping commands {:?}", self.commands);
-        if let Err(err) = self.cleanup.send(CleanupRequest::Commands(
-            self.commands.clone(),
-        )) {
-            warn!("failed to notify cleanup of commands {:?}: {}", self.commands, err);
+        if let Err(err) = self
+            .cleanup
+            .send(CleanupRequest::Commands(self.commands.clone()))
+        {
+            warn!(
+                "failed to notify cleanup of commands {:?}: {}",
+                self.commands, err
+            );
         }
     }
 }
@@ -608,7 +612,7 @@ impl ChatIngest for Arc<Server> {
 
 #[async_trait]
 impl Seabird for Arc<Server> {
-    type StreamEventsStream = mpsc::Receiver<RpcResult<proto::Event>>;
+    type StreamEventsStream = crate::wrapped::WrappedChannelReceiver<RpcResult<proto::Event>>;
 
     async fn stream_events(
         &self,
@@ -631,7 +635,7 @@ impl Seabird for Arc<Server> {
             commands.insert(name, metadata);
         }
 
-        let (mut sender, receiver) = mpsc::channel(CHAT_INGEST_SEND_BUFFER);
+        let (mut sender, receiver, mut notifier) = crate::wrapped::channel(CHAT_INGEST_SEND_BUFFER);
 
         let mut events = self.sender.subscribe();
 
@@ -645,14 +649,22 @@ impl Seabird for Arc<Server> {
             };
 
             loop {
-                let event = events.recv().await.map_err(|err| {
-                    Status::internal(format!("failed to read internal event: {:?}", err))
-                })?;
-
-                sender
-                    .send(Ok(event))
-                    .await
-                    .map_err(|err| Status::internal(format!("failed to send event: {}", err)))?;
+                match select(events.next(), &mut notifier).await {
+                    Either::Left((Some(Ok(event)), _)) => {
+                        sender.send(Ok(event)).await.map_err(|err| {
+                            Status::internal(format!("failed to send event: {}", err))
+                        })
+                    }
+                    Either::Left((Some(Err(err)), _)) => {
+                        Err(Status::internal(format!("failed to read internal event: {:?}", err)))
+                    }
+                    Either::Left((None, _)) => {
+                        Err(Status::internal(format!("this means something")))
+                    }
+                    Either::Right((_, _evt)) => {
+                        Err(Status::internal(format!("stream closed")))
+                    }
+                }?;
             }
         });
 

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -56,10 +56,10 @@ impl<T> Drop for WrappedChannelReceiver<T> {
     fn drop(&mut self) {
         if let Some(oneshot) = self.oneshot.take() {
             if let Err(_err) = oneshot.send(()) {
-                warn!("failed to notify");
+                error!("failed to notify");
             }
         } else {
-            warn!("oneshot already triggered");
+            error!("oneshot already triggered");
         }
     }
 }

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -4,6 +4,11 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::prelude::*;
 
+// channel returns a writer, reader, and a notification channel. Send/receive
+// mechanics are the same as an mpsc::channel, but there is an additional
+// oneshot notification channel which will fire when the receiver is dropped.
+// This is a workaround which lets us detect when a client has cleanly
+// disconnected with tonic gRPC streams.
 pub fn channel<T>(
     buffer_size: usize,
 ) -> (
@@ -24,6 +29,7 @@ pub fn channel<T>(
     )
 }
 
+// WrappedChannelSender is the Send side of a wrapped channel.
 #[derive(Debug, Clone)]
 pub struct WrappedChannelSender<T> {
     inner: mpsc::Sender<T>,
@@ -35,6 +41,7 @@ impl<T> WrappedChannelSender<T> {
     }
 }
 
+// WrappedChannelSender is the Stream side of a wrapped channel.
 #[derive(Debug)]
 pub struct WrappedChannelReceiver<T> {
     inner: mpsc::Receiver<T>,

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -1,0 +1,88 @@
+use async_trait::async_trait;
+use tokio::stream::Stream;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::prelude::*;
+
+pub fn channel<T>(
+    buffer_size: usize,
+) -> (
+    WrappedChannelSender<T>,
+    WrappedChannelReceiver<T>,
+    oneshot::Receiver<()>,
+) {
+    let (sender, receiver) = mpsc::channel(buffer_size);
+    let (oneshot_sender, oneshot_receiver) = oneshot::channel();
+
+    (
+        WrappedChannelSender { inner: sender },
+        WrappedChannelReceiver {
+            inner: receiver,
+            oneshot: Some(oneshot_sender),
+        },
+        oneshot_receiver,
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct WrappedChannelSender<T> {
+    inner: mpsc::Sender<T>,
+}
+
+impl<T> WrappedChannelSender<T> {
+    pub async fn send(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>> {
+        self.inner.send(value).await
+    }
+}
+
+#[derive(Debug)]
+pub struct WrappedChannelReceiver<T> {
+    inner: mpsc::Receiver<T>,
+    oneshot: Option<oneshot::Sender<()>>,
+}
+
+impl<T> Stream for WrappedChannelReceiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_recv(cx)
+    }
+}
+
+impl<T> Drop for WrappedChannelReceiver<T> {
+    fn drop(&mut self) {
+        if let Some(oneshot) = self.oneshot.take() {
+            if let Err(_err) = oneshot.send(()) {
+                warn!("failed to notify");
+            }
+        } else {
+            warn!("oneshot already triggered");
+        }
+    }
+}
+
+#[async_trait]
+pub trait GenericSender<T> {
+    async fn send_value(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>>;
+}
+
+#[async_trait]
+impl<T> GenericSender<T> for mpsc::Sender<T> where
+T: Send{
+    async fn send_value(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>> {
+        self.send(value).await
+    }
+}
+
+#[async_trait]
+impl<T> GenericSender<T> for WrappedChannelSender<T>
+where
+    T: Send,
+{
+    async fn send_value(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>> {
+        self.send(value).await
+    }
+}


### PR DESCRIPTION
Tonic drops the receiver when the stream is done, so we can wrap it and `impl Drop`. This allows us to detect when the stream is dropped and clean up without having to wait for another message to be sent.