### PR TITLE
Split ingest_events and auth out from server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,16 +11,14 @@ mod server;
 mod wrapped;
 
 use crate::prelude::*;
-use wrapped::GenericSender;
 
 pub mod error {
     pub use anyhow::{Error, Result};
     pub type RpcResult<T> = std::result::Result<T, tonic::Status>;
 }
 
-pub fn spawn<S, T, V>(mut sender: S, task: T)
+pub fn spawn<T, V>(task: T)
 where
-    S: GenericSender<T::Output> + Send + 'static,
     T: futures::Future<Output = RpcResult<V>> + Send + 'static,
     T::Output: Send + 'static,
     V: Send + 'static,
@@ -28,7 +26,6 @@ where
     tokio::spawn(async move {
         if let Err(err) = task.await {
             error!("error when running stream: {}", err);
-            let _ = sender.send_value(Err(err)).await;
         }
     });
 }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,0 +1,132 @@
+use crate::prelude::*;
+
+use hyper::{Body, Request as HyperRequest, Response as HyperResponse};
+use tonic::{body::BoxBody, transport::NamedService, Request};
+use tower::Service;
+
+const X_AUTH_USERNAME: &str = "x-auth-username";
+
+pub fn extract_auth_username<T>(req: &Request<T>) -> RpcResult<String> {
+    Ok(req
+        .metadata()
+        .get(X_AUTH_USERNAME)
+        .ok_or_else(|| Status::internal("missing auth username"))?
+        .to_str()
+        .map_err(|_| Status::internal("failed to decode auth username"))?
+        .to_string())
+}
+
+// AuthedService is a frustratingly necessary evil because there is no async
+// tonic::Interceptor. This means we can't .await on the RwLock protecting
+// server.tokens. We get around this by implementing a middleware which pulls
+// the request header out (since the http2 headers map to gRPC request metadata
+// directly) to check it before we even get into the gRPC/Tonic code.
+#[derive(Debug, Clone)]
+pub struct AuthedService<S> {
+    server: Arc<super::Server>,
+    inner: S,
+}
+
+impl<S> AuthedService<S> {
+    pub fn new(server: Arc<super::Server>, inner: S) -> Self {
+        AuthedService { server, inner }
+    }
+}
+
+impl<S> Service<HyperRequest<Body>> for AuthedService<S>
+where
+    S: Service<HyperRequest<Body>, Response = HyperResponse<BoxBody>>
+        + NamedService
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: HyperRequest<Body>) -> Self::Future {
+        let mut svc = self.inner.clone();
+        let server = self.server.clone();
+
+        Box::pin(async move {
+            let (mut req, username): (HyperRequest<Body>, tonic::codegen::http::HeaderValue) =
+                match req.headers().get("authorization") {
+                    Some(token) => {
+                        let token = match token.to_str() {
+                            Ok(token) => token,
+                            Err(_) => {
+                                return Ok(Status::unauthenticated("invalid token data").to_http())
+                            }
+                        };
+
+                        let mut split = token.splitn(2, ' ');
+                        match (split.next(), split.next()) {
+                            (Some("Bearer"), Some(token)) => {
+                                let tokens = server.tokens.read().await;
+                                match tokens.get(token) {
+                                    Some(maybe_username) => match maybe_username.parse() {
+                                        Ok(username) => (req, username),
+                                        Err(_) => {
+                                            return Ok(Status::internal(
+                                                "invalid auth token username",
+                                            )
+                                            .to_http())
+                                        }
+                                    },
+                                    None => {
+                                        return Ok(
+                                            Status::unauthenticated("invalid auth token").to_http()
+                                        )
+                                    }
+                                }
+                            }
+                            (Some("Bearer"), None) => {
+                                return Ok(Status::unauthenticated("missing auth token").to_http())
+                            }
+                            (Some(_), _) => {
+                                return Ok(Status::unauthenticated("unknown auth method").to_http())
+                            }
+                            (None, _) => {
+                                return Ok(Status::unauthenticated("missing auth method").to_http())
+                            }
+                        }
+                    }
+                    None => {
+                        return Ok(Status::unauthenticated("missing authorization header").to_http())
+                    }
+                };
+
+            let username_str = match username.to_str() {
+                Ok(username) => username,
+                Err(_) => return Ok(Status::internal("failed to parse tag").to_http()),
+            };
+
+            info!(
+                "Authenticated request by user {}: {}",
+                username_str,
+                req.uri()
+            );
+
+            req.headers_mut().insert(X_AUTH_USERNAME, username);
+
+            let resp = svc.call(req).await?;
+
+            info!("Sending response: {:?}", resp.headers());
+
+            Ok(resp)
+        })
+    }
+}
+
+impl<S: NamedService> NamedService for AuthedService<S> {
+    const NAME: &'static str = S::NAME;
+}

--- a/src/server/ingest_events.rs
+++ b/src/server/ingest_events.rs
@@ -1,0 +1,235 @@
+use futures::future::{select, Either};
+use tokio::sync::mpsc;
+
+use crate::prelude::*;
+use crate::proto::{ChatEventInner, EventInner};
+
+const CHAT_INGEST_SEND_BUFFER: usize = 10;
+
+pub struct IngestEvents {
+    id: BackendId,
+    backend: Arc<super::ChatBackend>,
+    backend_handle: super::ChatBackendHandle,
+    server: Arc<super::Server>,
+    input_stream: tonic::Streaming<proto::ChatEvent>,
+    request_sender: mpsc::Sender<RpcResult<proto::ChatRequest>>,
+}
+
+impl IngestEvents {
+    async fn new(
+        id: BackendId,
+        server: Arc<super::Server>,
+        input_stream: tonic::Streaming<proto::ChatEvent>,
+        request_sender: mpsc::Sender<RpcResult<proto::ChatRequest>>,
+    ) -> RpcResult<Self> {
+        let (backend_handle, backend) = server.register_backend(&id).await?;
+
+        Ok(IngestEvents {
+            id,
+            backend,
+            backend_handle,
+            server,
+            input_stream,
+            request_sender,
+        })
+    }
+
+    async fn handle_event(&mut self, event: proto::ChatEvent) -> RpcResult<()> {
+        debug!("got event: {:?}", event);
+
+        let inner = event
+            .inner
+            .ok_or_else(|| Status::internal("missing inner event"))?;
+
+        if event.id != "" {
+            self.server.respond(&event.id, inner.clone()).await;
+        }
+
+        match inner {
+            // These are only used for responding to
+            // requests, so we ignore them here because they
+            // don't need to be handled specially.
+            ChatEventInner::Success(_) => {}
+            ChatEventInner::Failed(_) => {}
+            ChatEventInner::Metadata(_) => {}
+
+            ChatEventInner::Action(action) => {
+                let _ = self.backend_handle.sender.send(proto::Event {
+                    inner: Some(EventInner::Action(proto::ActionEvent {
+                        source: action.source.map(|source| source.into_relative(&self.id)),
+                        text: action.text,
+                    })),
+                    tags: event.tags,
+                });
+            }
+            ChatEventInner::PrivateAction(private_action) => {
+                let _ = self.backend_handle.sender.send(proto::Event {
+                    inner: Some(EventInner::PrivateAction(proto::PrivateActionEvent {
+                        source: private_action
+                            .source
+                            .map(|source| source.into_relative(&self.id)),
+                        text: private_action.text,
+                    })),
+                    tags: event.tags,
+                });
+            }
+            ChatEventInner::Message(msg) => {
+                let _ = self.backend_handle.sender.send(proto::Event {
+                    inner: Some(EventInner::Message(proto::MessageEvent {
+                        source: msg.source.map(|source| source.into_relative(&self.id)),
+                        text: msg.text,
+                    })),
+                    tags: event.tags,
+                });
+            }
+            ChatEventInner::PrivateMessage(private_msg) => {
+                let _ = self.backend_handle.sender.send(proto::Event {
+                    inner: Some(EventInner::PrivateMessage(proto::PrivateMessageEvent {
+                        source: private_msg.source.map(|user| user.into_relative(&self.id)),
+                        text: private_msg.text,
+                    })),
+                    tags: event.tags,
+                });
+            }
+            ChatEventInner::Command(cmd_msg) => {
+                let _ = self.backend_handle.sender.send(proto::Event {
+                    inner: Some(EventInner::Command(proto::CommandEvent {
+                        source: cmd_msg.source.map(|source| source.into_relative(&self.id)),
+                        command: cmd_msg.command,
+                        arg: cmd_msg.arg,
+                    })),
+                    tags: event.tags,
+                });
+            }
+            ChatEventInner::Mention(mention_msg) => {
+                let _ = self.backend_handle.sender.send(proto::Event {
+                    inner: Some(EventInner::Mention(proto::MentionEvent {
+                        source: mention_msg
+                            .source
+                            .map(|source| source.into_relative(&self.id)),
+                        text: mention_msg.text,
+                    })),
+                    tags: event.tags,
+                });
+            }
+
+            ChatEventInner::JoinChannel(join) => {
+                let mut channels = self.backend.channels.write().await;
+
+                channels.insert(
+                    join.channel_id.clone(),
+                    proto::Channel {
+                        id: join.channel_id,
+                        display_name: join.display_name,
+                        topic: join.topic,
+                    },
+                );
+            }
+            ChatEventInner::LeaveChannel(leave) => {
+                let mut channels = self.backend.channels.write().await;
+
+                channels.remove(&leave.channel_id);
+            }
+            ChatEventInner::ChangeChannel(change) => {
+                let mut channels = self.backend.channels.write().await;
+
+                if let Some(channel) = channels.get_mut(&change.channel_id) {
+                    channel.display_name = change.display_name;
+                    channel.topic = change.topic;
+                }
+            }
+
+            // If a hello comes through, this client has broken
+            // the protocol contract, so we kill the connection.
+            ChatEventInner::Hello(_) => {
+                return Err(Status::invalid_argument("unexpected chat event type"))
+            }
+        }
+
+        return Ok(());
+    }
+
+    async fn run(mut self) -> RpcResult<()> {
+        loop {
+            match select(
+                self.backend_handle.receiver.next(),
+                self.input_stream.next(),
+            )
+            .await
+            {
+                Either::Left((Some(req), _)) => {
+                    debug!("got request: {:?}", req);
+
+                    self.request_sender.send(Ok(req)).await.map_err(|err| {
+                        Status::internal(format!("failed to send request to backend: {:?}", err))
+                    })?;
+                }
+                Either::Right((Some(event), _)) => {
+                    let event = event?;
+                    self.handle_event(event).await?;
+                }
+                Either::Left((None, _)) => {
+                    return Err(Status::internal("internal request stream ended"))
+                }
+                Either::Right((None, _)) => {
+                    return Err(Status::internal("chat event stream ended"))
+                }
+            };
+        }
+    }
+}
+
+pub struct IngestEventsHandle {
+    receiver: mpsc::Receiver<RpcResult<proto::ChatRequest>>,
+}
+
+impl IngestEventsHandle {
+    pub fn new(
+        server: Arc<super::Server>,
+        mut input_stream: tonic::Streaming<proto::ChatEvent>,
+    ) -> IngestEventsHandle {
+        let (sender, receiver) = mpsc::channel(CHAT_INGEST_SEND_BUFFER);
+
+        crate::spawn(async move {
+            let hello = {
+                // TODO: send to the stream and print
+                let first_message = input_stream
+                    .message()
+                    .await?
+                    .ok_or_else(|| Status::invalid_argument("missing hello message"))?;
+
+                match first_message.inner {
+                    Some(ChatEventInner::Hello(hello)) => hello,
+                    Some(_) => {
+                        return Err(Status::invalid_argument(
+                            "hello message inner is wrong type",
+                        ))
+                    }
+                    None => return Err(Status::invalid_argument("missing hello message inner")),
+                }
+            };
+
+            let backend_info = hello
+                .backend_info
+                .ok_or_else(|| Status::invalid_argument("missing backend_info inner"))?;
+
+            let id = BackendId::new(backend_info.r#type, backend_info.id);
+
+            let ingest_events_actor = IngestEvents::new(id, server, input_stream, sender).await?;
+            ingest_events_actor.run().await
+        });
+
+        IngestEventsHandle { receiver }
+    }
+}
+
+impl futures::Stream for IngestEventsHandle {
+    type Item = RpcResult<proto::ChatRequest>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -70,26 +70,3 @@ impl<T> Drop for WrappedChannelReceiver<T> {
         }
     }
 }
-
-#[async_trait]
-pub trait GenericSender<T> {
-    async fn send_value(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>>;
-}
-
-#[async_trait]
-impl<T> GenericSender<T> for mpsc::Sender<T> where
-T: Send{
-    async fn send_value(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>> {
-        self.send(value).await
-    }
-}
-
-#[async_trait]
-impl<T> GenericSender<T> for WrappedChannelSender<T>
-where
-    T: Send,
-{
-    async fn send_value(&mut self, value: T) -> Result<(), mpsc::error::SendError<T>> {
-        self.send(value).await
-    }
-}


### PR DESCRIPTION
This makes a few changes, but for the most part, it's just splitting server.rs into auth.rs, ingest_events.rs, and mod.rs.

Also note that in `crate::spawn`, the call to sender.send was removed because this was causing a panic - when a network connection died, it would cause the backend to be cleaned up (which removes the reference to the receiver). When the receiver is gone, sends will panic.

So, crate::spawn should only be used for long running processes which don't need to report their status over the network if they fail.